### PR TITLE
Fix an expired link

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ location /filebrowser {
 
 ### Supported environment variables
 
-The environment variables are prefixed by `FB_` followed by the option name in caps. So to set "database" via an env variable, you should set FB_DATABASE. The list of avalable options can be [found here](https://filebrowser.xyz/cli/filebrowser#options).
+The environment variables are prefixed by `FB_` followed by the option name in caps. So to set "database" via an env variable, you should set FB_DATABASE. The list of avalable options can be [found here](https://filebrowser.org/cli/filebrowser#options).
 
 ### Supported volumes
 


### PR DESCRIPTION
The reference link which points to Filebrowser's supported environment variables was broken, it removed to the new domain filebrowser.org, not filebrowser.xyz any more.