### PR TITLE
Fix bug for downloading latest release of filebrowser

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -99,7 +99,7 @@ install_filemanager()
 	echo "Downloading File Browser for $filemanager_os/$filemanager_arch..."
 	filemanager_file="${filemanager_os}-$filemanager_arch-filebrowser$filemanager_dl_ext"
 	# filemanager_tag="$(curl -s https://api.github.com/repos/filebrowser/filebrowser/releases/latest | grep -o '"tag_name": ".*"' | sed 's/"//g' | sed 's/tag_name: //g')"
-	filemanager_url="https://github.com/filebrowser/filebrowser/releases/download/$filemanager_tag/$filemanager_file"
+	filemanager_url="https://github.com/filebrowser/filebrowser/releases/latest/download/$filemanager_file"
 	echo "$filemanager_url"
 
 	# Use $PREFIX for compatibility with Termux on Android


### PR DESCRIPTION
This version can now build [v2.26.0](https://github.com/filebrowser/filebrowser/releases/tag/v2.26.0) (latest release at the time of writing).